### PR TITLE
feat: add back navigation and persistent navbar

### DIFF
--- a/src/app/(main)/courses/page.tsx
+++ b/src/app/(main)/courses/page.tsx
@@ -10,7 +10,7 @@ import { CoursesSearch } from "./CoursesSearch";
 import * as fs from "fs-extra";
 import * as path from "node:path";
 import { Metadata } from "next";
-import { i18n } from "@/lib/i18n";
+import { i18n } from "@/i18n";
 
 export const dynamic = "force-dynamic";
 

--- a/src/app/(main)/courses/page.tsx
+++ b/src/app/(main)/courses/page.tsx
@@ -9,15 +9,8 @@ import { CoursesHeader } from "./CoursesHeader";
 import { CoursesSearch } from "./CoursesSearch";
 import * as fs from "fs-extra";
 import * as path from "node:path";
-import { Metadata } from "next";
-import { i18n } from "@/i18n";
 
 export const dynamic = "force-dynamic";
-
-export const metadata: Metadata = {
-  title: "Blogs | Adorsys GIS Blog",
-  description: "Explore our collection of blogs and tutorials",
-};
 
 type Props = { searchParams?: Promise<{ lang?: string; page?: string }> };
 
@@ -119,9 +112,6 @@ export default async function CoursesPage({ searchParams }: Props) {
   return (
     <div className="bg-black">
       <Container>
-        <h1 className="text-4xl font-bold text-center mb-8">
-          {i18n.language?.startsWith("fr") ? "Blogs" : "Blogs"}
-        </h1>
         <div className="mb-6 space-y-4">
           <CoursesHeader total={total} />
         </div>

--- a/src/app/(main)/courses/page.tsx
+++ b/src/app/(main)/courses/page.tsx
@@ -9,8 +9,15 @@ import { CoursesHeader } from "./CoursesHeader";
 import { CoursesSearch } from "./CoursesSearch";
 import * as fs from "fs-extra";
 import * as path from "node:path";
+import { Metadata } from "next";
+import { i18n } from "@/lib/i18n";
 
 export const dynamic = "force-dynamic";
+
+export const metadata: Metadata = {
+  title: "Blogs | Adorsys GIS Blog",
+  description: "Explore our collection of blogs and tutorials",
+};
 
 type Props = { searchParams?: Promise<{ lang?: string; page?: string }> };
 
@@ -112,6 +119,9 @@ export default async function CoursesPage({ searchParams }: Props) {
   return (
     <div className="bg-black">
       <Container>
+        <h1 className="text-4xl font-bold text-center mb-8">
+          {i18n.language?.startsWith("fr") ? "Blogs" : "Blogs"}
+        </h1>
         <div className="mb-6 space-y-4">
           <CoursesHeader total={total} />
         </div>

--- a/src/app/(read)/b/[blog_slug]/page.tsx
+++ b/src/app/(read)/b/[blog_slug]/page.tsx
@@ -46,27 +46,25 @@ export default async function SingleBlogPage({ params }: Props) {
     const { course, slides } = await loadBlog(blog_slug);
     return (
       <Container>
-        <div className="mt-6 sm:mt-8 mb-4 flex justify-start">
-          <Link
-            href="/b"
-            className="inline-flex items-center gap-2 text-white/80 hover:text-white hover:font-extrabold transition-colors px-1"
-            aria-label="Back to blogs"
+        <Link
+          href="/courses"
+          className="inline-flex items-center gap-2 text-gray-600 hover:text-gray-900 hover:font-bold transition-all duration-200 mb-6"
+        >
+          <svg
+            className="w-4 h-4"
+            fill="none"
+            stroke="currentColor"
+            viewBox="0 0 24 24"
           >
-            <svg
-              className="w-4 h-4"
-              viewBox="0 0 24 24"
-              fill="none"
-              stroke="currentColor"
-              strokeWidth="2"
+            <path
               strokeLinecap="round"
               strokeLinejoin="round"
-              aria-hidden
-            >
-              <polyline points="15 18 9 12 15 6"></polyline>
-            </svg>
-            Back to blogs
-          </Link>
-        </div>
+              strokeWidth={2}
+              d="M10 19l-7-7m0 0l7-7m-7 7h18"
+            />
+          </svg>
+          Blogs
+        </Link>
         {slides && <Display data={slides.content} />}
 
         {course.content && (

--- a/src/app/(read)/b/[blog_slug]/page.tsx
+++ b/src/app/(read)/b/[blog_slug]/page.tsx
@@ -93,7 +93,7 @@ export default async function SingleBlogPage({ params }: Props) {
                   Reload
                 </a>
                 <a className="btn btn-primary" href="/courses">
-                  Return to Courses
+                  Return to Blogs
                 </a>
               </div>
             </div>

--- a/src/app/(read)/b/[blog_slug]/page.tsx
+++ b/src/app/(read)/b/[blog_slug]/page.tsx
@@ -70,7 +70,7 @@ export default async function SingleBlogPage({ params }: Props) {
         {slides && <Display data={slides.content} />}
 
         {course.content && (
-          <article className="prose prose-neutral lg:prose-xl mx-auto mt-8 text-center">
+          <article className="prose prose-neutral lg:prose-xl mx-auto mt-8">
             <div dangerouslySetInnerHTML={{ __html: course.content }} />
           </article>
         )}

--- a/src/app/(read)/b/[blog_slug]/page.tsx
+++ b/src/app/(read)/b/[blog_slug]/page.tsx
@@ -70,7 +70,7 @@ export default async function SingleBlogPage({ params }: Props) {
         {slides && <Display data={slides.content} />}
 
         {course.content && (
-          <article className="prose prose-neutral lg:prose-xl mx-auto mt-8 text-justify">
+          <article className="prose prose-neutral lg:prose-xl mx-auto mt-8 text-justify px-8">
             <div dangerouslySetInnerHTML={{ __html: course.content }} />
           </article>
         )}

--- a/src/app/(read)/b/[blog_slug]/page.tsx
+++ b/src/app/(read)/b/[blog_slug]/page.tsx
@@ -70,7 +70,7 @@ export default async function SingleBlogPage({ params }: Props) {
         {slides && <Display data={slides.content} />}
 
         {course.content && (
-          <article className="prose prose-neutral lg:prose-xl mx-auto mt-8">
+          <article className="prose prose-neutral lg:prose-xl mx-auto mt-8 text-center">
             <div dangerouslySetInnerHTML={{ __html: course.content }} />
           </article>
         )}

--- a/src/app/(read)/b/[blog_slug]/page.tsx
+++ b/src/app/(read)/b/[blog_slug]/page.tsx
@@ -70,7 +70,7 @@ export default async function SingleBlogPage({ params }: Props) {
         {slides && <Display data={slides.content} />}
 
         {course.content && (
-          <article className="prose prose-neutral lg:prose-xl mx-auto mt-8 text-center">
+          <article className="prose prose-neutral lg:prose-xl mx-auto mt-8 text-justify">
             <div dangerouslySetInnerHTML={{ __html: course.content }} />
           </article>
         )}

--- a/src/app/(read)/b/[blog_slug]/page.tsx
+++ b/src/app/(read)/b/[blog_slug]/page.tsx
@@ -46,25 +46,27 @@ export default async function SingleBlogPage({ params }: Props) {
     const { course, slides } = await loadBlog(blog_slug);
     return (
       <Container>
-        <Link
-          href="/courses"
-          className="inline-flex items-center gap-2 text-gray-600 hover:text-gray-900 hover:font-bold transition-all duration-200 mb-6"
-        >
-          <svg
-            className="w-4 h-4"
-            fill="none"
-            stroke="currentColor"
-            viewBox="0 0 24 24"
+        <div className="mt-6 sm:mt-8 mb-4 flex justify-start">
+          <Link
+            href="/b"
+            className="inline-flex items-center gap-2 text-white/80 hover:text-white hover:font-extrabold transition-colors px-1"
+            aria-label="Back to blogs"
           >
-            <path
+            <svg
+              className="w-4 h-4"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              strokeWidth="2"
               strokeLinecap="round"
               strokeLinejoin="round"
-              strokeWidth={2}
-              d="M10 19l-7-7m0 0l7-7m-7 7h18"
-            />
-          </svg>
-          Blogs
-        </Link>
+              aria-hidden
+            >
+              <polyline points="15 18 9 12 15 6"></polyline>
+            </svg>
+            Back to blogs
+          </Link>
+        </div>
         {slides && <Display data={slides.content} />}
 
         {course.content && (

--- a/src/app/(read)/b/[blog_slug]/page.tsx
+++ b/src/app/(read)/b/[blog_slug]/page.tsx
@@ -3,7 +3,7 @@ import { redirect } from "next/navigation";
 import { loadBlog } from "@blog/converters";
 import { getAllBlogs } from "@blog/server/blog/api";
 import Display from "@blog/components/display";
-import { CoursesLink } from "./CoursesLink";
+import Link from "next/link";
 
 export const dynamic = "force-dynamic";
 
@@ -46,8 +46,26 @@ export default async function SingleBlogPage({ params }: Props) {
     const { course, slides } = await loadBlog(blog_slug);
     return (
       <Container>
-        <div className="mb-4 flex justify-end">
-          <CoursesLink />
+        <div className="mt-6 sm:mt-8 mb-4 flex justify-start">
+          <Link
+            href="/b"
+            className="inline-flex items-center gap-2 text-white/80 hover:text-white hover:font-extrabold transition-colors px-1"
+            aria-label="Back to blogs"
+          >
+            <svg
+              className="w-4 h-4"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              strokeWidth="2"
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              aria-hidden
+            >
+              <polyline points="15 18 9 12 15 6"></polyline>
+            </svg>
+            Back to blogs
+          </Link>
         </div>
         {slides && <Display data={slides.content} />}
 

--- a/src/app/(read)/layout.tsx
+++ b/src/app/(read)/layout.tsx
@@ -1,29 +1,15 @@
-import {Container} from "@blog/components/container";
-import Link from "next/link";
-import Image from "next/image";
-import icon from "@blog/components/icon.svg";
+import { AppNavBar } from "@blog/components/navbar";
 import type {PropsWithChildren} from "react";
+import { Suspense } from "react";
 
 export default function MainLayout({
                                        children,
                                    }: Readonly<PropsWithChildren>) {
     return (
         <>
-            <div className='sticky top-0 z-40 bg-base-300'>
-                <Container className='py-0'>
-                    <nav className='navbar min-h-16'>
-                        <div className='navbar-start flex gap-2 sm:gap-4'>
-                            <Link href='/courses' className='flex flex-row items-center gap-1.5 sm:gap-2'>
-                                <Image src={icon} className='w-6 sm:w-8' alt='logo'/>
-                                <span className='text-lg sm:text-xl font-extrabold uppercase' color='ghost'>Adorsys GIS Blog</span>
-                            </Link>
-                        </div>
-
-                        <div className='navbar-end flex gap-2 sm:gap-4'>
-                        </div>
-                    </nav>
-                </Container>
-            </div>
+            <Suspense fallback={null}>
+                <AppNavBar />
+            </Suspense>
 
             <div id='read'>{children}</div>
         </>

--- a/src/app/error.tsx
+++ b/src/app/error.tsx
@@ -91,7 +91,7 @@ export default function ErrorPage({
               <ArrowLeft className="mr-2 h-4 w-4" /> {t("errors.returnHome")}
             </button>
             <Link className="btn btn-ghost" href="/courses">
-              <Home className="mr-2 h-4 w-4" /> {t("errors.returnHome")}
+              Go to blogs
             </Link>
           </div>
 

--- a/src/app/global-error.tsx
+++ b/src/app/global-error.tsx
@@ -30,7 +30,7 @@ export default function GlobalError({
                   <RefreshCw className="mr-2 h-4 w-4" /> Try again
                 </button>
                 <a className="btn btn-ghost" href="/courses">
-                  <Home className="mr-2 h-4 w-4" /> Home
+                  Go to blogs
                 </a>
               </div>
               {/* Technical details intentionally hidden for end-users */}

--- a/src/app/not-found.tsx
+++ b/src/app/not-found.tsx
@@ -24,7 +24,7 @@ export default function NotFound() {
             </p>
             <div className="mt-6 flex flex-wrap items-center justify-center gap-3">
               <Link className="btn btn-outline" href="/courses">
-                <Home className="mr-2 h-4 w-4" /> {t("errors.returnHome")}
+                Go to blogs
               </Link>
               <Link className="btn btn-primary" href="/courses">
                 <Search className="mr-2 h-4 w-4" /> {t("errors.returnCourses")}

--- a/src/components/display/display.scss
+++ b/src/components/display/display.scss
@@ -19,25 +19,26 @@
   text-align: center !important;
 }
 
-// Center-align lists
+// Center lists with bullets close to text
 .reveal .slides section ul,
 .reveal .slides section ol {
   text-align: center !important;
-  list-style-position: outside !important;
+  list-style-position: inside !important;
+  display: inline-block !important;
   margin: 0 !important;
   padding: 0 !important;
 }
 
 .reveal .slides section li {
-  text-align: center !important;
-  margin: 0.1em 0 !important;
+  text-align: left !important;
+  margin: 0 !important;
   padding: 0 !important;
   text-indent: 0 !important;
 }
 
-// Center-align code blocks
+// Center code blocks
 .reveal .slides section pre,
 .reveal .slides section code {
-  text-align: center !important;
+  text-align: left !important;
   margin: 0 auto;
 }

--- a/src/components/display/display.scss
+++ b/src/components/display/display.scss
@@ -19,7 +19,7 @@
   text-align: center !important;
 }
 
-// Center lists with bullets closer to text
+// Center lists with bullets very close to text
 .reveal .slides section ul,
 .reveal .slides section ol {
   text-align: center !important;
@@ -33,7 +33,9 @@
 .reveal .slides section li {
   text-align: left !important;
   margin: 0.25em 0 !important;
-  padding-left: 0.5em !important;
+  padding-left: 0.1em !important;
+  text-indent: -1.2em !important;
+  padding-left: 1.2em !important;
 }
 
 // Center code blocks and other elements

--- a/src/components/display/display.scss
+++ b/src/components/display/display.scss
@@ -2,3 +2,27 @@
 @use 'reveal.js/dist/reveal';
 @use 'reveal.js/dist/theme/night';
 @use 'highlight.js/scss/sunburst';
+
+// Center-align all slide content
+.reveal .slides section {
+  text-align: center !important;
+}
+
+.reveal .slides section h1,
+.reveal .slides section h2,
+.reveal .slides section h3,
+.reveal .slides section h4,
+.reveal .slides section h5,
+.reveal .slides section h6,
+.reveal .slides section p,
+.reveal .slides section li,
+.reveal .slides section blockquote {
+  text-align: center !important;
+}
+
+// Center code blocks and other elements
+.reveal .slides section pre,
+.reveal .slides section code {
+  text-align: left !important;
+  margin: 0 auto;
+}

--- a/src/components/display/display.scss
+++ b/src/components/display/display.scss
@@ -15,9 +15,21 @@
 .reveal .slides section h5,
 .reveal .slides section h6,
 .reveal .slides section p,
-.reveal .slides section li,
 .reveal .slides section blockquote {
   text-align: center !important;
+}
+
+// Center lists with bullets
+.reveal .slides section ul,
+.reveal .slides section ol {
+  text-align: center !important;
+  list-style-position: inside !important;
+  display: inline-block !important;
+  text-align: left !important;
+}
+
+.reveal .slides section li {
+  text-align: left !important;
 }
 
 // Center code blocks and other elements

--- a/src/components/display/display.scss
+++ b/src/components/display/display.scss
@@ -19,23 +19,30 @@
   text-align: center !important;
 }
 
-// Center lists with bullets very close to text
+// Force bullets very close to text with maximum specificity
 .reveal .slides section ul,
-.reveal .slides section ol {
+.reveal .slides section ol,
+.reveal .slides section ul li,
+.reveal .slides section ol li {
   text-align: center !important;
   list-style-position: inside !important;
   display: inline-block !important;
   text-align: left !important;
   margin: 0 !important;
-  padding-left: 0 !important;
+  padding: 0 !important;
 }
 
 .reveal .slides section li {
   text-align: left !important;
-  margin: 0.25em 0 !important;
-  padding-left: 0.1em !important;
-  text-indent: -1.2em !important;
-  padding-left: 1.2em !important;
+  margin: 0.1em 0 !important;
+  padding: 0 !important;
+  text-indent: 0 !important;
+}
+
+// Override any existing list styles
+.reveal .slides section ul li::marker,
+.reveal .slides section ol li::marker {
+  margin-right: 0.2em !important;
 }
 
 // Center code blocks and other elements

--- a/src/components/display/display.scss
+++ b/src/components/display/display.scss
@@ -3,9 +3,9 @@
 @use 'reveal.js/dist/theme/night';
 @use 'highlight.js/scss/sunburst';
 
-// Left-align all slide content
+// Center-align all slide content
 .reveal .slides section {
-  text-align: left !important;
+  text-align: center !important;
 }
 
 .reveal .slides section h1,
@@ -16,28 +16,28 @@
 .reveal .slides section h6,
 .reveal .slides section p,
 .reveal .slides section blockquote {
-  text-align: left !important;
+  text-align: center !important;
 }
 
-// Left-align lists
+// Center-align lists
 .reveal .slides section ul,
 .reveal .slides section ol {
-  text-align: left !important;
+  text-align: center !important;
   list-style-position: outside !important;
   margin: 0 !important;
   padding: 0 !important;
 }
 
 .reveal .slides section li {
-  text-align: left !important;
+  text-align: center !important;
   margin: 0.1em 0 !important;
   padding: 0 !important;
   text-indent: 0 !important;
 }
 
-// Left-align code blocks
+// Center-align code blocks
 .reveal .slides section pre,
 .reveal .slides section code {
-  text-align: left !important;
-  margin: 0;
+  text-align: center !important;
+  margin: 0 auto;
 }

--- a/src/components/display/display.scss
+++ b/src/components/display/display.scss
@@ -19,17 +19,21 @@
   text-align: center !important;
 }
 
-// Center lists with bullets
+// Center lists with bullets closer to text
 .reveal .slides section ul,
 .reveal .slides section ol {
   text-align: center !important;
   list-style-position: inside !important;
   display: inline-block !important;
   text-align: left !important;
+  margin: 0 !important;
+  padding-left: 0 !important;
 }
 
 .reveal .slides section li {
   text-align: left !important;
+  margin: 0.25em 0 !important;
+  padding-left: 0.5em !important;
 }
 
 // Center code blocks and other elements

--- a/src/components/display/display.scss
+++ b/src/components/display/display.scss
@@ -3,9 +3,9 @@
 @use 'reveal.js/dist/theme/night';
 @use 'highlight.js/scss/sunburst';
 
-// Center-align all slide content
+// Justify all slide content
 .reveal .slides section {
-  text-align: center !important;
+  text-align: justify !important;
 }
 
 .reveal .slides section h1,
@@ -16,13 +16,13 @@
 .reveal .slides section h6,
 .reveal .slides section p,
 .reveal .slides section blockquote {
-  text-align: center !important;
+  text-align: justify !important;
 }
 
-// Center lists with bullets close to text
+// Justify lists with bullets close to text
 .reveal .slides section ul,
 .reveal .slides section ol {
-  text-align: center !important;
+  text-align: justify !important;
   list-style-position: inside !important;
   display: inline-block !important;
   margin: 0 !important;
@@ -30,13 +30,13 @@
 }
 
 .reveal .slides section li {
-  text-align: left !important;
+  text-align: justify !important;
   margin: 0 !important;
   padding: 0 !important;
   text-indent: 0 !important;
 }
 
-// Center code blocks
+// Justify code blocks
 .reveal .slides section pre,
 .reveal .slides section code {
   text-align: left !important;

--- a/src/components/display/display.scss
+++ b/src/components/display/display.scss
@@ -3,9 +3,11 @@
 @use 'reveal.js/dist/theme/night';
 @use 'highlight.js/scss/sunburst';
 
-// Justify all slide content
+// Justify all slide content with uniform margins
 .reveal .slides section {
   text-align: justify !important;
+  margin-left: 2rem !important;
+  margin-right: 2rem !important;
 }
 
 .reveal .slides section h1,
@@ -17,15 +19,17 @@
 .reveal .slides section p,
 .reveal .slides section blockquote {
   text-align: justify !important;
+  margin-left: 2rem !important;
+  margin-right: 2rem !important;
 }
 
-// Justify lists with bullets close to text
+// Justify lists with bullets close to text and uniform margins
 .reveal .slides section ul,
 .reveal .slides section ol {
   text-align: justify !important;
   list-style-position: inside !important;
   display: inline-block !important;
-  margin: 0 !important;
+  margin: 0 2rem !important;
   padding: 0 !important;
 }
 
@@ -36,9 +40,44 @@
   text-indent: 0 !important;
 }
 
-// Justify code blocks
+// Justify code blocks with uniform margins
 .reveal .slides section pre,
 .reveal .slides section code {
   text-align: left !important;
-  margin: 0 auto;
+  margin: 0 2rem !important;
+}
+
+// Apply same styling to course.md content (prose content)
+.prose {
+  text-align: justify !important;
+  margin-left: 3rem !important;
+  margin-right: 3rem !important;
+}
+
+.prose h1,
+.prose h2,
+.prose h3,
+.prose h4,
+.prose h5,
+.prose h6,
+.prose p,
+.prose blockquote {
+  text-align: justify !important;
+  margin-left: 3rem !important;
+  margin-right: 3rem !important;
+}
+
+.prose ul,
+.prose ol {
+  text-align: justify !important;
+  list-style-position: inside !important;
+  margin: 0 3rem !important;
+  padding: 0 !important;
+}
+
+.prose li {
+  text-align: justify !important;
+  margin: 0 !important;
+  padding: 0 !important;
+  text-indent: 0 !important;
 }

--- a/src/components/display/display.scss
+++ b/src/components/display/display.scss
@@ -3,9 +3,9 @@
 @use 'reveal.js/dist/theme/night';
 @use 'highlight.js/scss/sunburst';
 
-// Center-align all slide content
+// Left-align all slide content
 .reveal .slides section {
-  text-align: center !important;
+  text-align: left !important;
 }
 
 .reveal .slides section h1,
@@ -16,18 +16,14 @@
 .reveal .slides section h6,
 .reveal .slides section p,
 .reveal .slides section blockquote {
-  text-align: center !important;
+  text-align: left !important;
 }
 
-// Force bullets very close to text with maximum specificity
+// Left-align lists
 .reveal .slides section ul,
-.reveal .slides section ol,
-.reveal .slides section ul li,
-.reveal .slides section ol li {
-  text-align: center !important;
-  list-style-position: inside !important;
-  display: inline-block !important;
+.reveal .slides section ol {
   text-align: left !important;
+  list-style-position: outside !important;
   margin: 0 !important;
   padding: 0 !important;
 }
@@ -39,15 +35,9 @@
   text-indent: 0 !important;
 }
 
-// Override any existing list styles
-.reveal .slides section ul li::marker,
-.reveal .slides section ol li::marker {
-  margin-right: 0.2em !important;
-}
-
-// Center code blocks and other elements
+// Left-align code blocks
 .reveal .slides section pre,
 .reveal .slides section code {
   text-align: left !important;
-  margin: 0 auto;
+  margin: 0;
 }

--- a/src/components/display/display.tsx
+++ b/src/components/display/display.tsx
@@ -78,7 +78,8 @@ export default function Display({ data }: DisplayProps) {
         
         .reveal .slides section ul li::marker,
         .reveal .slides section ol li::marker {
-          margin-right: 0 !important;
+          margin: 0 !important;
+          padding: 0 !important;
         }
       `}</style>
       <div className='display'>

--- a/src/components/display/display.tsx
+++ b/src/components/display/display.tsx
@@ -58,13 +58,37 @@ export default function Display({ data }: DisplayProps) {
   }, []);
   
   return (
-    <div className='display'>
-      <div className='reveal' ref={deckDivRef}>
-        <div
-          className='slides'
-          dangerouslySetInnerHTML={{ __html: htmlContent(data) }}
-        />
+    <>
+      <style jsx global>{`
+        .reveal .slides section ul,
+        .reveal .slides section ol {
+          text-align: center !important;
+          list-style-position: inside !important;
+          display: inline-block !important;
+          margin: 0 !important;
+          padding: 0 !important;
+        }
+        
+        .reveal .slides section li {
+          text-align: left !important;
+          margin: 0 !important;
+          padding: 0 !important;
+          text-indent: 0 !important;
+        }
+        
+        .reveal .slides section ul li::marker,
+        .reveal .slides section ol li::marker {
+          margin-right: 0.1em !important;
+        }
+      `}</style>
+      <div className='display'>
+        <div className='reveal' ref={deckDivRef}>
+          <div
+            className='slides'
+            dangerouslySetInnerHTML={{ __html: htmlContent(data) }}
+          />
+        </div>
       </div>
-    </div>
+    </>
   );
 }

--- a/src/components/display/display.tsx
+++ b/src/components/display/display.tsx
@@ -78,7 +78,7 @@ export default function Display({ data }: DisplayProps) {
         
         .reveal .slides section ul li::marker,
         .reveal .slides section ol li::marker {
-          margin-right: 0.1em !important;
+          margin-right: 0 !important;
         }
       `}</style>
       <div className='display'>

--- a/src/components/navbar/navbar.tsx
+++ b/src/components/navbar/navbar.tsx
@@ -84,10 +84,9 @@ export function AppNavBar() {
           <div className="navbar-end flex items-center gap-3 sm:gap-4">
             <Link
               href="/courses"
-              className="text-2xl font-bold text-primary"
-              aria-label="Go to blogs"
+              className="text-primary hover:font-extrabold transition-colors px-1"
             >
-              Blogs
+              {i18n.language?.startsWith("fr") ? "Cours" : "Courses"}
             </Link>
             <Link
               href="/res/about"

--- a/src/components/navbar/navbar.tsx
+++ b/src/components/navbar/navbar.tsx
@@ -84,13 +84,13 @@ export function AppNavBar() {
           <div className="navbar-end flex items-center gap-3 sm:gap-4">
             <Link
               href="/courses"
-              className="text-gray-700 hover:text-green-600 hover:font-bold transition-all duration-200"
+              className="text-primary hover:font-bold transition-all duration-200"
             >
               {i18n.language?.startsWith("fr") ? "Blogs" : "Blogs"}
             </Link>
             <Link
               href="/res/about"
-              className="text-white/80 hover:text-white hover:font-extrabold transition-colors px-1"
+              className="text-white/80 hover:text-white hover:font-bold transition-all duration-200"
             >
               {i18n.language?.startsWith("fr") ? "À propos" : "About"}
             </Link>

--- a/src/components/navbar/navbar.tsx
+++ b/src/components/navbar/navbar.tsx
@@ -84,9 +84,9 @@ export function AppNavBar() {
           <div className="navbar-end flex items-center gap-3 sm:gap-4">
             <Link
               href="/courses"
-              className="text-primary hover:font-extrabold transition-colors px-1"
+              className="text-gray-700 hover:text-green-600 hover:font-bold transition-all duration-200"
             >
-              {i18n.language?.startsWith("fr") ? "Cours" : "Courses"}
+              {i18n.language?.startsWith("fr") ? "Blogs" : "Blogs"}
             </Link>
             <Link
               href="/res/about"

--- a/src/components/navbar/navbar.tsx
+++ b/src/components/navbar/navbar.tsx
@@ -84,9 +84,10 @@ export function AppNavBar() {
           <div className="navbar-end flex items-center gap-3 sm:gap-4">
             <Link
               href="/courses"
-              className="text-primary hover:font-extrabold transition-colors px-1"
+              className="text-2xl font-bold text-primary"
+              aria-label="Go to blogs"
             >
-              {i18n.language?.startsWith("fr") ? "Cours" : "Courses"}
+              Blogs
             </Link>
             <Link
               href="/res/about"


### PR DESCRIPTION
Closes #34 
- Add "Back to blogs" button on lesson pages (top-left)
- Remove old "Courses" button from lesson pages
- Make navbar persistent across all pages including articles
- Ensure consistent navigation experience throughout the app