### PR TITLE
Improve responsiveness across pages

### DIFF
--- a/src/app/(main)/courses/CoursesSearch.tsx
+++ b/src/app/(main)/courses/CoursesSearch.tsx
@@ -20,7 +20,7 @@ export function CoursesSearch({ children }: PropsWithChildren) {
 
   return (
     <div className="w-full">
-      <div className="mb-3 sm:mb-4 mx-auto w-full md:w-3/4 lg:w-1/2">
+      <div className="mb-3 sm:mb-4 mx-auto w-full md:w-3/4 lg:w-1/2 max-w-3xl px-4 sm:px-0">
         <form
           className="flex items-center gap-2"
           onSubmit={(e) => {
@@ -69,7 +69,7 @@ export function CoursesSearch({ children }: PropsWithChildren) {
       </div>
 
       {enabled ? (
-        <div className="mt-25 sm:mt-35">
+        <div className="mt-8 sm:mt-12 md:mt-16 xl:mt-20">
           {isFetching && (
             <div className="text-xs sm:text-sm opacity-70">{t("search.searching")}</div>
           )}
@@ -91,7 +91,7 @@ export function CoursesSearch({ children }: PropsWithChildren) {
           </div>
         </div>
       ) : (
-        <div className="mt-25 sm:mt-35">{children}</div>
+        <div className="mt-8 sm:mt-12 md:mt-16 xl:mt-20">{children}</div>
       )}
     </div>
   );

--- a/src/app/(main)/courses/page.tsx
+++ b/src/app/(main)/courses/page.tsx
@@ -22,7 +22,7 @@ export default async function CoursesPage({ searchParams }: Props) {
   const pageParam =
     typeof params?.page === "string" ? parseInt(params.page, 10) : 1;
   const page = Number.isFinite(pageParam) && pageParam > 0 ? pageParam : 1;
-  const perPage = 6;
+  const perPage = 8;
 
   const slugs = await getAllBlogs();
   const courses = await Promise.all(
@@ -119,7 +119,7 @@ export default async function CoursesPage({ searchParams }: Props) {
             <CoursesHeader total={total} />
           </div>
           <CoursesSearch>
-            <div className="grid grid-cols-1 gap-6 sm:gap-8 sm:grid-cols-2 lg:grid-cols-3">
+            <div className="grid grid-cols-1 gap-5 sm:gap-6 md:gap-8 lg:gap-10 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4">
               {pageItems.map(
                 ({ slug, title, description, lang, previews, tags, date }) => (
                   <CourseCard

--- a/src/app/(read)/b/[blog_slug]/page.tsx
+++ b/src/app/(read)/b/[blog_slug]/page.tsx
@@ -72,7 +72,7 @@ export default async function SingleBlogPage({ params }: Props) {
         {slides && <Display data={slides.content} />}
 
         {course.content && (
-          <article className="prose prose-neutral lg:prose-xl mx-auto mt-8 text-justify px-8">
+          <article className="prose prose-neutral lg:prose-xl mx-auto mt-8 text-justify px-4 sm:px-6 lg:px-8">
             <div dangerouslySetInnerHTML={{ __html: course.content }} />
           </article>
         )}

--- a/src/components/footer/large-footer.tsx
+++ b/src/components/footer/large-footer.tsx
@@ -12,7 +12,7 @@ export default function LargeFooter() {
   return (
     <div className="bg-black/60 border-t border-white/10">
       <Container>
-        <footer className="footer py-8 sm:py-10 sm:footer-horizontal text-white/85">
+        <footer className="footer py-8 sm:py-10 sm:footer-horizontal text-white/85 gap-6 sm:gap-8">
           <aside className="text-center sm:text-left">
             <Image
               src={icon}
@@ -28,7 +28,7 @@ export default function LargeFooter() {
           </aside>
 
           {/* Social links */}
-          <div className="flex items-center justify-center md:justify-end gap-3 sm:gap-4">
+          <div className="flex flex-wrap items-center justify-center md:justify-end gap-3 sm:gap-4">
             <a
               href="#"
               target="_blank"
@@ -72,7 +72,7 @@ export default function LargeFooter() {
           </div>
 
           {/* Mobile: COMPANY and LEGAL on same line */}
-          <div className="flex flex-row justify-center md:hidden gap-8">
+          <div className="flex flex-row flex-wrap justify-center md:hidden gap-6">
             <nav className="text-center">
               <h6 className="footer-title text-base">{t("footer.company")}</h6>
               <div className="flex flex-col gap-1">

--- a/src/components/pagination/pagination.tsx
+++ b/src/components/pagination/pagination.tsx
@@ -72,7 +72,7 @@ export function Pagination({
   return (
     <nav
       aria-label="Course navigation"
-      className="flex items-center gap-2 rounded-md bg-black text-neutral-300"
+      className="flex flex-wrap items-center justify-center gap-1 sm:gap-2 rounded-md bg-black text-neutral-300"
     >
       {/* Previous */}
       <Link
@@ -85,7 +85,7 @@ export function Pagination({
           isPrevDisabled
             ? "pointer-events-none cursor-not-allowed text-neutral-600"
             : "hover:text-white"
-        } px-2 py-1 text-xs`}
+        } px-1.5 py-1 text-[11px] sm:px-2 sm:py-1.5 sm:text-xs`}
       >
         <span className="flex items-center gap-1">
           <svg
@@ -109,7 +109,7 @@ export function Pagination({
       </Link>
 
       {/* Pages */}
-      <div className="flex items-center gap-2">
+      <div className="flex flex-wrap items-center justify-center gap-1 sm:gap-2">
         {visiblePages.map((page) => (
           <Link
             key={page}
@@ -124,7 +124,7 @@ export function Pagination({
               page === currentPage
                 ? "bg-neutral-800 text-white"
                 : "bg-black text-neutral-300 hover:text-white"
-            } border border-neutral-800 rounded px-2 py-1 text-xs`}
+            } border border-neutral-800 rounded px-1.5 py-1 text-[11px] sm:px-2 sm:py-1.5 sm:text-xs`}
           >
             <span>{page}</span>
           </Link>
@@ -142,7 +142,7 @@ export function Pagination({
           isNextDisabled
             ? "pointer-events-none cursor-not-allowed text-neutral-600"
             : "hover:text-white"
-        } px-2 py-1 text-xs`}
+        } px-1.5 py-1 text-[11px] sm:px-2 sm:py-1.5 sm:text-xs`}
       >
         <span className="flex items-center gap-1">
           <span className="hidden sm:inline">{t("Next")}</span>


### PR DESCRIPTION
This PR refines responsive behavior across the main blog listing, search, pagination, footer, and article pages.  
It also increases the number of blogs per page from 6 to 8 for a more content-dense experience while keeping layout readable on all breakpoints.

## Key Changes

### Courses Grid (`src/app/(main)/courses/page.tsx`)
- Increase per-page count from **6 → 8**  
- Make grid scale better: `xl:grid-cols-4` with tuned gaps for each breakpoint  

### Search Area (`src/app/(main)/courses/CoursesSearch.tsx`)
- Constrain input width with `max-w-3xl` and small-screen padding  
- Replace non-standard spacing with responsive margins: `mt-8 sm:mt-12 md:mt-16 xl:mt-20`  
- Preserve search results grid and behavior  

### Pagination (`src/components/pagination/pagination.tsx`)
- Add `flex-wrap` and centering for small screens  
- Reduce pill sizes slightly at small breakpoints; scale up on larger ones  
- Keep current/hover states and accessibility attributes intact  

### Footer (`src/components/footer/large-footer.tsx`)
- Wrap social links and sections on small screens  
- Use consistent gaps for compact layouts  

### Article Page Padding (`src/app/(read)/b/[blog_slug]/page.tsx`)
- Reduce side padding on small screens: `px-4 sm:px-6 lg:px-8`  

## UX Impact
- Better card density on large screens (up to 4 columns on `xl`)  
- Tighter, more readable spacing on mobile for search and content  
- Pagination adapts reliably across mobile and tablet widths  
- Footer elements don’t overflow on small devices  

## Accessibility
- Pagination preserves labels/ARIA for next/previous and current page  
- No interactive behaviors removed; focus rings unaffected  

## Performance
- Purely CSS/layout changes and one per-page constant update  
- No additional network calls or client JS introduced  
